### PR TITLE
Fix: Run when invoked via .bin symlink

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import fs from 'fs/promises'
+import { realpathSync } from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import { Command, program } from 'commander'
@@ -62,6 +63,6 @@ export async function run () {
   }
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+if (process.argv[1] && realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
   run()
 }


### PR DESCRIPTION
### Fixes #103

### Fix
- Compare the realpath of `process.argv[1]` against `import.meta.url` so the CLI runs when invoked via the `.bin` symlink (`npx at-utils` / `node_modules/.bin/at-utils`), not only when `index.js` is executed directly.

### Testing
- [x] `npx at-utils` now prints the version banner and command list
- [x] `npx at-utils deps-check --help` runs the subcommand
- [x] `node index.js` (direct invocation) still works
- [x] `npx standard` passes