### PR TITLE
New: add ci-status command for dependency CI checks (fixes #110)

### DIFF
--- a/bin/ci-status.js
+++ b/bin/ci-status.js
@@ -1,0 +1,88 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import CliCommand from '../lib/CliCommand.js'
+import githubRequest from '../lib/utils/githubRequest.js'
+import loadJson from '../lib/utils/loadJson.js'
+import parseRepoSlug from '../lib/utils/parseRepoSlug.js'
+import aggregateCiState from '../lib/utils/aggregateCiState.js'
+import ciStatusEmoji from '../lib/utils/ciStatusEmoji.js'
+import renderCiStatusTable from '../lib/utils/renderCiStatusTable.js'
+import spliceReadmeSection from '../lib/utils/spliceReadmeSection.js'
+
+export default class CiStatus extends CliCommand {
+  get config () {
+    return {
+      ...super.config,
+      description: "Reports the latest CI run on each dependency repo's default branch",
+      params: {},
+      options: [
+        ['--json', 'Output results as JSON'],
+        ['--update-readme', 'Splice the status table into README.md between the ci-status markers']
+      ],
+      getReleaseData: false
+    }
+  }
+
+  async runTask () {
+    const cwd = this.options.cwd || process.cwd()
+
+    let repos
+    try {
+      repos = await loadJson(join(cwd, 'bin', 'repos.json'))
+    } catch (e) {
+      console.error(`Could not read bin/repos.json in ${cwd}. Run this from the umbrella repository root.`)
+      process.exitCode = 1
+      return
+    }
+
+    const rows = await Promise.all(repos.map(repo => this.checkRepo(repo)))
+    rows.sort((a, b) => a.repo < b.repo ? -1 : 1)
+
+    if (this.options.updateReadme) {
+      await this.updateReadme(cwd, rows)
+      return
+    }
+
+    if (this.options.json) {
+      console.log(JSON.stringify(rows, null, 2))
+    } else {
+      this.printTable(rows)
+    }
+
+    // A non-zero exit lets the command double as a CI gate; the dashboard
+    // (--update-readme) always succeeds so red dependencies still get published.
+    if (rows.some(row => row.state !== 'pass')) process.exitCode = 1
+  }
+
+  async checkRepo (entry) {
+    const repo = parseRepoSlug(entry.url)
+    const actionsUrl = `https://github.com/${repo}/actions`
+    try {
+      const { default_branch: branch } = await githubRequest('', { repo })
+      const { workflow_runs: runs } = await githubRequest(
+        `actions/runs?branch=${encodeURIComponent(branch)}&per_page=30`, { repo }
+      )
+      const { state, url } = aggregateCiState(runs)
+      return { name: entry.name, repo, branch, state, url: url || actionsUrl }
+    } catch (e) {
+      return { name: entry.name, repo, branch: null, state: 'error', url: actionsUrl }
+    }
+  }
+
+  printTable (rows) {
+    const width = Math.max(...rows.map(row => row.name.length))
+    rows.forEach(row => console.log(`${ciStatusEmoji(row.state)} ${row.name.padEnd(width)}  ${row.state}`))
+
+    const failing = rows.filter(row => row.state !== 'pass')
+    console.log(`\n${rows.length - failing.length}/${rows.length} passing.`)
+    if (failing.length) console.log(`Not passing: ${failing.map(row => row.name).join(', ')}`)
+  }
+
+  async updateReadme (cwd, rows) {
+    const updated = new Date().toISOString().slice(0, 16).replace('T', ' ') + ' UTC'
+    const readmePath = join(cwd, 'README.md')
+    const content = await readFile(readmePath, 'utf8')
+    await writeFile(readmePath, spliceReadmeSection(content, renderCiStatusTable(rows, updated)))
+    console.log(`Updated ${readmePath}`)
+  }
+}

--- a/lib/utils/aggregateCiState.js
+++ b/lib/utils/aggregateCiState.js
@@ -1,0 +1,33 @@
+const PASS_CONCLUSIONS = new Set(['success', 'neutral', 'skipped'])
+
+// Given the recent Actions runs for a branch (newest first), computes a single
+// CI state for the most recent commit that ran CI — the newest run's head_sha —
+// aggregating across every workflow triggered for that commit. Reruns are
+// resolved to the latest run per workflow. A single push commonly triggers
+// several workflows, so the latest run alone is not a reliable signal.
+//
+// Returns { state, url, sha } where state is:
+//   none | <status> (e.g. in_progress) | pass | <conclusion> (e.g. failure)
+export default function aggregateCiState (runs) {
+  if (!runs || runs.length === 0) return { state: 'none', url: null, sha: null }
+
+  const newest = runs.reduce((a, b) => b.created_at > a.created_at ? b : a)
+  const sha = newest.head_sha
+
+  const latestPerWorkflow = new Map()
+  for (const run of runs) {
+    if (run.head_sha !== sha) continue
+    const key = run.workflow_id ?? run.name
+    const current = latestPerWorkflow.get(key)
+    if (!current || run.created_at > current.created_at) latestPerWorkflow.set(key, run)
+  }
+  const relevant = [...latestPerWorkflow.values()]
+
+  const incomplete = relevant.find(run => run.status !== 'completed')
+  if (incomplete) return { state: incomplete.status, url: incomplete.html_url, sha }
+
+  const failed = relevant.find(run => !PASS_CONCLUSIONS.has(run.conclusion))
+  if (failed) return { state: failed.conclusion || 'unknown', url: failed.html_url, sha }
+
+  return { state: 'pass', url: newest.html_url, sha }
+}

--- a/lib/utils/ciStatusEmoji.js
+++ b/lib/utils/ciStatusEmoji.js
@@ -1,0 +1,19 @@
+const EMOJI = {
+  pass: '✅',
+  failure: '❌',
+  cancelled: '❌',
+  timed_out: '❌',
+  startup_failure: '❌',
+  action_required: '❌',
+  in_progress: '🟡',
+  queued: '🟡',
+  requested: '🟡',
+  waiting: '🟡',
+  pending: '🟡',
+  none: '⚪️',
+  error: '⚠️'
+}
+
+export default function ciStatusEmoji (state) {
+  return EMOJI[state] || '❔'
+}

--- a/lib/utils/githubRequest.js
+++ b/lib/utils/githubRequest.js
@@ -6,7 +6,8 @@ export default async function githubRequest (endpoint, opts = {}) {
   const repo = opts.repo || DEFAULT_REPO
   delete opts.repo
   opts.headers = { ...githubHeaders(), ...opts.headers }
-  const response = await fetch(`https://api.github.com/repos/${repo}/${endpoint}`, opts)
+  const url = `https://api.github.com/repos/${repo}${endpoint ? `/${endpoint}` : ''}`
+  const response = await fetch(url, opts)
   if (response.status > 299) {
     const isRateLimit = response.status === 429 ||
       (response.status === 403 && response.headers.get('X-RateLimit-Remaining') === '0')

--- a/lib/utils/parseRepoSlug.js
+++ b/lib/utils/parseRepoSlug.js
@@ -1,0 +1,5 @@
+export default function parseRepoSlug (url) {
+  const match = url.match(/github\.com[:/]([^/]+\/[^/]+?)(?:\.git)?$/)
+  if (!match) throw new Error(`Could not parse a GitHub repo from URL: ${url}`)
+  return match[1]
+}

--- a/lib/utils/renderCiStatusTable.js
+++ b/lib/utils/renderCiStatusTable.js
@@ -1,0 +1,16 @@
+import ciStatusEmoji from './ciStatusEmoji.js'
+
+export default function renderCiStatusTable (rows, updated) {
+  const lines = [
+    '## Dependency CI status',
+    '',
+    `_Latest run on each repo's default branch. Updated ${updated}._`,
+    '',
+    '| Module | Status |',
+    '| --- | --- |'
+  ]
+  for (const row of rows) {
+    lines.push(`| [${row.name}](${row.url}) | ${ciStatusEmoji(row.state)} \`${row.state}\` |`)
+  }
+  return lines.join('\n')
+}

--- a/lib/utils/spliceReadmeSection.js
+++ b/lib/utils/spliceReadmeSection.js
@@ -1,0 +1,13 @@
+const START = '<!-- ci-status:start -->'
+const END = '<!-- ci-status:end -->'
+
+// Replaces the content between the ci-status markers with the given section,
+// leaving the markers in place. Throws if the markers are missing or malformed.
+export default function spliceReadmeSection (content, section, start = START, end = END) {
+  const startIdx = content.indexOf(start)
+  const endIdx = content.indexOf(end)
+  if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) {
+    throw new Error(`Could not find ci-status markers (${start} … ${end})`)
+  }
+  return content.slice(0, startIdx + start.length) + '\n' + section + '\n' + content.slice(endIdx)
+}

--- a/tests/aggregateCiState.spec.js
+++ b/tests/aggregateCiState.spec.js
@@ -1,0 +1,73 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import aggregateCiState from '../lib/utils/aggregateCiState.js'
+
+const run = (over = {}) => ({
+  head_sha: 'aaa',
+  workflow_id: 1,
+  name: 'Tests',
+  status: 'completed',
+  conclusion: 'success',
+  created_at: '2026-06-17T12:00:00Z',
+  html_url: 'https://example.com/run',
+  ...over
+})
+
+describe('aggregateCiState', () => {
+  it('returns none for no runs', () => {
+    assert.deepEqual(aggregateCiState([]), { state: 'none', url: null, sha: null })
+    assert.equal(aggregateCiState(undefined).state, 'none')
+  })
+
+  it('passes when all workflows for the latest commit succeed', () => {
+    const runs = [
+      run({ workflow_id: 1, name: 'Tests' }),
+      run({ workflow_id: 2, name: 'Lint' }),
+      run({ workflow_id: 3, name: 'Release' })
+    ]
+    assert.equal(aggregateCiState(runs).state, 'pass')
+  })
+
+  it('fails if any workflow for the latest commit fails (the multi-workflow case)', () => {
+    const runs = [
+      run({ workflow_id: 1, name: 'Tests', conclusion: 'failure', html_url: 'https://example.com/tests' }),
+      run({ workflow_id: 2, name: 'Lint', conclusion: 'success' }),
+      run({ workflow_id: 3, name: 'Release', conclusion: 'success' })
+    ]
+    const result = aggregateCiState(runs)
+    assert.equal(result.state, 'failure')
+    assert.equal(result.url, 'https://example.com/tests')
+  })
+
+  it('only considers the newest commit, ignoring older passing/failing runs', () => {
+    const runs = [
+      run({ head_sha: 'new', created_at: '2026-06-17T13:00:00Z', conclusion: 'success' }),
+      run({ head_sha: 'old', created_at: '2026-06-17T10:00:00Z', conclusion: 'failure' })
+    ]
+    assert.equal(aggregateCiState(runs).state, 'pass')
+  })
+
+  it('resolves reruns to the latest run per workflow', () => {
+    const runs = [
+      run({ workflow_id: 1, created_at: '2026-06-17T12:30:00Z', conclusion: 'success' }),
+      run({ workflow_id: 1, created_at: '2026-06-17T12:00:00Z', conclusion: 'failure' })
+    ]
+    assert.equal(aggregateCiState(runs).state, 'pass')
+  })
+
+  it('reports an in-progress run before judging conclusions', () => {
+    const runs = [
+      run({ workflow_id: 1, status: 'in_progress', conclusion: null }),
+      run({ workflow_id: 2, conclusion: 'failure' })
+    ]
+    assert.equal(aggregateCiState(runs).state, 'in_progress')
+  })
+
+  it('treats neutral and skipped as passing', () => {
+    const runs = [
+      run({ workflow_id: 1, conclusion: 'skipped' }),
+      run({ workflow_id: 2, conclusion: 'neutral' })
+    ]
+    assert.equal(aggregateCiState(runs).state, 'pass')
+  })
+})

--- a/tests/ciStatusEmoji.spec.js
+++ b/tests/ciStatusEmoji.spec.js
@@ -1,0 +1,18 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import ciStatusEmoji from '../lib/utils/ciStatusEmoji.js'
+
+describe('ciStatusEmoji', () => {
+  const cases = [
+    ['pass', '✅'],
+    ['failure', '❌'],
+    ['cancelled', '❌'],
+    ['in_progress', '🟡'],
+    ['none', '⚪️'],
+    ['error', '⚠️'],
+    ['something-unexpected', '❔']
+  ]
+  for (const [state, expected] of cases) {
+    it(`maps '${state}'`, () => assert.equal(ciStatusEmoji(state), expected))
+  }
+})

--- a/tests/parseRepoSlug.spec.js
+++ b/tests/parseRepoSlug.spec.js
@@ -1,0 +1,19 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import parseRepoSlug from '../lib/utils/parseRepoSlug.js'
+
+describe('parseRepoSlug', () => {
+  const cases = [
+    ['git@github.com:adapt-security/adapt-authoring-core.git', 'adapt-security/adapt-authoring-core'],
+    ['git@github.com:cgkineo/adapt-authoring-collab.git', 'cgkineo/adapt-authoring-collab'],
+    ['https://github.com/adaptlearning/adapt-cli.git', 'adaptlearning/adapt-cli'],
+    ['https://github.com/adaptlearning/adapt-cli', 'adaptlearning/adapt-cli']
+  ]
+  for (const [url, expected] of cases) {
+    it(`parses ${url}`, () => assert.equal(parseRepoSlug(url), expected))
+  }
+
+  it('throws on a non-GitHub URL', () => {
+    assert.throws(() => parseRepoSlug('https://example.com/foo/bar'), /Could not parse/)
+  })
+})

--- a/tests/spliceReadmeSection.spec.js
+++ b/tests/spliceReadmeSection.spec.js
@@ -1,0 +1,27 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import spliceReadmeSection from '../lib/utils/spliceReadmeSection.js'
+
+const START = '<!-- ci-status:start -->'
+const END = '<!-- ci-status:end -->'
+
+describe('spliceReadmeSection', () => {
+  it('replaces content between the markers', () => {
+    const content = `# Title\n\n${START}\nold\n${END}\n\nFooter\n`
+    const result = spliceReadmeSection(content, 'NEW')
+    assert.equal(result, `# Title\n\n${START}\nNEW\n${END}\n\nFooter\n`)
+  })
+
+  it('works when the markers are empty', () => {
+    const content = `${START}\n${END}`
+    assert.equal(spliceReadmeSection(content, 'TABLE'), `${START}\nTABLE\n${END}`)
+  })
+
+  it('throws when markers are missing', () => {
+    assert.throws(() => spliceReadmeSection('no markers here', 'X'), /Could not find/)
+  })
+
+  it('throws when end precedes start', () => {
+    assert.throws(() => spliceReadmeSection(`${END}\n${START}`, 'X'), /Could not find/)
+  })
+})


### PR DESCRIPTION
### Fixes #110

### New
* Add `ci-status` command reporting the latest CI run on each dependency repo's default branch — reads `bin/repos.json`, aggregates all workflows for the latest commit (so a single red workflow shows red), and skips `[skip ci]` release commits by anchoring on the latest run's commit. Supports `--json` and `--update-readme` (splices a status table between `<!-- ci-status -->` markers in README.md).

### Fix
* `githubRequest` now targets the repo root when the endpoint is empty (it previously appended a trailing slash that returned 404), enabling repo-metadata lookups such as the default branch.

### Testing
1. From the umbrella repo root: `GITHUB_USER=<user> GITHUB_TOKEN=<token> npx at-utils ci-status`
2. `npm test` (unit tests cover the new utils, including the multi-workflow aggregation case)