### PR TITLE
Fix: Resolve langpack glob safely on Windows paths

### DIFF
--- a/bin/lang-check.js
+++ b/bin/lang-check.js
@@ -54,7 +54,7 @@ export default class Langcheck extends CliCommand {
   }
 
   async getTranslatedStrings (root) {
-    const langPacks = await glob(`${root}/adapt-authoring-*/lang`)
+    const langPacks = await glob('adapt-authoring-*/lang', { cwd: root, absolute: true })
     const keyMap = {}
     await Promise.all(langPacks.map(async langDir => {
       const files = await glob('**/*.json', { cwd: langDir, absolute: true })

--- a/tests/lang-check.spec.js
+++ b/tests/lang-check.spec.js
@@ -1,0 +1,24 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import Langcheck from '../bin/lang-check.js'
+
+describe('Langcheck', () => {
+  describe('#getTranslatedStrings()', () => {
+    it('should collect strings when the root contains glob-significant characters', async () => {
+      // interpolating root into the pattern would parse '[id]' as a char class (and '\' as an escape on Windows)
+      const root = join(tmpdir(), `lang-check-root[id]-${Date.now()}`)
+      const langDir = join(root, 'adapt-authoring-foo', 'lang', 'en')
+      try {
+        mkdirSync(langDir, { recursive: true })
+        writeFileSync(join(langDir, 'app.json'), JSON.stringify({ title: 'x' }))
+        const keyMap = await Langcheck.prototype.getTranslatedStrings(root)
+        assert.deepEqual(keyMap.en, { 'app.title': false })
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    })
+  })
+})


### PR DESCRIPTION
### Fix
- `getTranslatedStrings()` built its langpack glob by interpolating `root` into the pattern (`${root}/adapt-authoring-*/lang`). On Windows the `\` separators are interpreted as glob escape characters (and any glob-significant character in the path breaks matching on every platform), so no langpacks are found. The path is now passed via the `cwd` option with `absolute: true`, matching the three already-safe `glob` calls in the same file.

### Testing
- Added a `getTranslatedStrings()` test using a root containing glob-significant characters (`[id]`); it fails without the fix on all platforms.