### PR TITLE
Update: make lang-check reconcile declared keys against translations (fixes #118)

### DIFF
--- a/bin/lang-check.js
+++ b/bin/lang-check.js
@@ -1,13 +1,17 @@
 import CliCommand from '../lib/CliCommand.js'
+import { reconcileLangKeys } from '../lib/utils/reconcileLangKeys.js'
 import fs from 'node:fs/promises'
 import { glob } from 'glob'
 import path from 'node:path'
+
+// match both unscoped (adapt-authoring-*) and scoped (@scope/adapt-authoring-*) modules
+const modulePattern = sub => ['adapt-authoring-*/' + sub, '@*/adapt-authoring-*/' + sub]
 
 export default class Langcheck extends CliCommand {
   get config () {
     return {
       ...super.config,
-      description: 'Checks for unused and missing language strings'
+      description: 'Checks that declared language keys have translations (and vice versa)'
     }
   }
 
@@ -16,7 +20,10 @@ export default class Langcheck extends CliCommand {
 
     this.underline('Language String Check')
 
+    const declared = await this.getDeclaredKeys(root)
     const translatedStrings = await this.getTranslatedStrings(root)
+    const usedInCode = await this.getUsedInCode(root)
+
     console.log('\n  Languages found:')
     Object.keys(translatedStrings).forEach(l => console.log('  -', l))
 
@@ -24,26 +31,31 @@ export default class Langcheck extends CliCommand {
       console.log('\n')
       this.underline(`Language: ${lang}`.toUpperCase())
 
-      const langStrings = translatedStrings[lang]
-      const usedStrings = await this.getUsedStrings(root, langStrings)
-      const unusedStrings = Object.entries(langStrings).filter(([k, v]) => !k.startsWith('error.') && !v).map(([k]) => k)
-      const missingStrings = Object.entries(usedStrings)
-        .filter(([key]) => !langStrings[key] && !key.startsWith('error') && key !== 'app.js')
-        .map(([key, locations]) => `${key}${locations}`)
+      // error strings are out of scope — they are handled by the error registry
+      const translated = Object.keys(translatedStrings[lang]).filter(k => !k.startsWith('error.'))
+      const { missing, orphan } = reconcileLangKeys({ declared, translated })
 
       console.log()
-      if (unusedStrings.length) {
-        this.logStrings(unusedStrings, 'translated strings unreferenced in the code')
+      // missing translations are a real defect (the raw key would be shown) — these fail the check
+      if (missing.length) {
+        this.logStrings(missing, 'declared keys without a translation')
         console.log()
       }
-      if (missingStrings.length) {
-        this.logStrings(missingStrings, 'strings without translation')
+      // orphaned translations are hygiene (unused, or a dynamic key not declared) — warn only
+      if (orphan.length) {
+        this.logWarning(orphan, 'translated keys no module declares')
         console.log()
       }
-      if (!unusedStrings.length && !missingStrings.length) {
+      if (!missing.length && !orphan.length) {
         console.log('✓ No issues found!\n')
       }
-      this.underline(`Summary:\n  - ${unusedStrings.length} unused language strings found\n  - ${missingStrings.length} missing language strings found`)
+      this.underline(`Summary:\n  - ${missing.length} missing translations (fail)\n  - ${orphan.length} orphaned translations (warn)`)
+    }
+
+    const undeclaredUsed = [...usedInCode].filter(key => !this.isDeclared(key, declared))
+    if (undeclaredUsed.length) {
+      console.log('\n')
+      this.logWarning(undeclaredUsed, 'key(s) used in code but not declared in any strings/*.json')
     }
     console.log()
   }
@@ -53,8 +65,25 @@ export default class Langcheck extends CliCommand {
     console.log(`${topLine ? line + '\n' : ''}  ${s}\n${line}`)
   }
 
+  isDeclared (key, declared) {
+    if (declared[key]) return true
+    return Object.entries(declared).some(([dk, def]) => def?.pattern && key.startsWith(dk))
+  }
+
+  async getDeclaredKeys (root) {
+    const declared = {}
+    const stringFiles = await glob(modulePattern('strings/*.json'), { cwd: root, absolute: true })
+    await Promise.all(stringFiles.map(async f => {
+      const contents = JSON.parse(await fs.readFile(f))
+      Object.entries(contents).forEach(([k, v]) => {
+        if (!declared[k]) declared[k] = v && typeof v === 'object' ? v : {}
+      })
+    }))
+    return declared
+  }
+
   async getTranslatedStrings (root) {
-    const langPacks = await glob('adapt-authoring-*/lang', { cwd: root, absolute: true })
+    const langPacks = await glob(modulePattern('lang'), { cwd: root, absolute: true })
     const keyMap = {}
     await Promise.all(langPacks.map(async langDir => {
       const files = await glob('**/*.json', { cwd: langDir, absolute: true })
@@ -73,35 +102,16 @@ export default class Langcheck extends CliCommand {
     return keyMap
   }
 
-  async getUsedStrings (root, translatedStrings) {
-    const usedStrings = {}
-    const errorFiles = await glob('adapt-authoring-*/errors/*.json', { cwd: root, absolute: true })
-    await Promise.all(errorFiles.map(async f => {
-      Object.keys(JSON.parse((await fs.readFile(f)))).forEach(e => {
-        const key = `error.${e}`
-        if (!usedStrings[key]) usedStrings[key] = new Set()
-        usedStrings[key].add(f.replace(root, '').split('/')[1]) // only add module name for errors
-      })
-    }))
-    const sourceFiles = await glob('adapt-authoring-*/**/*.@(js|hbs)', { cwd: root, absolute: true, ignore: ['**/node_modules/**', '**/*.spec.js', '**/tests/**'] })
-
+  async getUsedInCode (root) {
+    const used = new Set()
+    const sourceFiles = await glob(modulePattern('**/*.@(js|hbs)'), { cwd: root, absolute: true, ignore: ['**/node_modules/**', '**/*.spec.js', '**/tests/**'] })
     await Promise.all(sourceFiles.map(async f => {
       const contents = (await fs.readFile(f)).toString()
-      const allMatches = contents.matchAll(/(['"`])((?:app|error)\.[\w.]+)\1/g)
-
-      for (const m of allMatches) {
-        const key = m[2]
-        if (Object.hasOwn(translatedStrings, key)) {
-          translatedStrings[key] = true
-        }
-        if (!usedStrings[key]) usedStrings[key] = new Set()
-        usedStrings[key].add(f.replace(root, ''))
+      for (const m of contents.matchAll(/(['"`])(app\.[\w.]+)\1/g)) {
+        if (m[2] !== 'app.js') used.add(m[2])
       }
     }))
-    Object.entries(usedStrings).forEach(([k, set]) => {
-      usedStrings[k] = `${Array.from(set).map(s => `\n    ${s}`).join('')}`
-    })
-    return usedStrings
+    return used
   }
 
   logStrings (strings, message) {
@@ -109,7 +119,12 @@ export default class Langcheck extends CliCommand {
       return console.log(`✓ No ${message}`)
     }
     this.underline(`Found ${strings.length} ${message}`)
-    console.log(`${strings.map(s => `\n- ${s}`).join('')}`)
+    console.log(`${[...strings].sort().map(s => `\n- ${s}`).join('')}`)
     process.exitCode = 1
+  }
+
+  logWarning (strings, message) {
+    this.underline(`Warning: ${strings.length} ${message}`)
+    console.log(`${[...strings].sort().map(s => `\n- ${s}`).join('')}`)
   }
 }

--- a/lib/utils/reconcileLangKeys.js
+++ b/lib/utils/reconcileLangKeys.js
@@ -1,0 +1,27 @@
+/**
+ * Reconciles the language keys modules declare they expect against the keys a
+ * langpack actually translates. A declared entry flagged `pattern: true` is
+ * treated as a key prefix (a dynamic family) rather than an exact key.
+ * @param {Object} options
+ * @param {Object} options.declared Map of declared key to its definition (a definition may set `pattern: true`)
+ * @param {Array<String>|Object} options.translated The available translated keys (array, or object whose keys are used)
+ * @returns {{ missing: Array<String>, orphan: Array<String> }} `missing` = declared keys with no translation; `orphan` = translated keys nothing declares
+ */
+export function reconcileLangKeys ({ declared = {}, translated = [] } = {}) {
+  const translatedKeys = Array.isArray(translated) ? translated : Object.keys(translated)
+  const translatedSet = new Set(translatedKeys)
+  const declaredKeys = Object.keys(declared)
+  const patterns = declaredKeys.filter(k => declared[k]?.pattern)
+
+  const missing = declaredKeys.filter(k => {
+    return declared[k]?.pattern
+      ? !translatedKeys.some(t => t.startsWith(k))
+      : !translatedSet.has(k)
+  })
+
+  const orphan = translatedKeys.filter(t => {
+    return !declaredKeys.includes(t) && !patterns.some(p => t.startsWith(p))
+  })
+
+  return { missing, orphan }
+}

--- a/tests/lang-check.spec.js
+++ b/tests/lang-check.spec.js
@@ -1,10 +1,14 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
-import { join } from 'node:path'
+import { join, dirname } from 'node:path'
 import { tmpdir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
 import Langcheck from '../bin/lang-check.js'
 import { reconcileLangKeys } from '../lib/utils/reconcileLangKeys.js'
+
+const INDEX = join(dirname(fileURLToPath(import.meta.url)), '..', 'index.js')
 
 async function withRoot (build, run) {
   // interpolating root into a glob pattern would parse '[id]' as a char class
@@ -88,6 +92,43 @@ describe('Langcheck', () => {
           assert.deepEqual(orphan.sort(), ['app.extra'])
         }
       )
+    })
+  })
+
+  describe('exit code (CI failure signal)', () => {
+    function runCli (build) {
+      const root = join(tmpdir(), `lang-check-cli-${Date.now()}-${process.hrtime()[1]}`)
+      try {
+        build(root)
+        return spawnSync('node', [INDEX, 'lang-check'], { cwd: root, encoding: 'utf8' })
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    }
+
+    it('exits non-zero when a declared key has no translation', () => {
+      const res = runCli(root => {
+        writeJson(join(root, 'node_modules', 'adapt-authoring-foo', 'strings'), 'strings.json', { 'app.needed': {} })
+        writeJson(join(root, 'node_modules', 'adapt-authoring-foo', 'lang', 'en'), 'app.json', { present: 'x' })
+      })
+      assert.equal(res.status, 1)
+    })
+
+    it('exits zero when every declared key is translated', () => {
+      const res = runCli(root => {
+        writeJson(join(root, 'node_modules', 'adapt-authoring-foo', 'strings'), 'strings.json', { 'app.present': {} })
+        writeJson(join(root, 'node_modules', 'adapt-authoring-foo', 'lang', 'en'), 'app.json', { present: 'x' })
+      })
+      assert.equal(res.status, 0)
+    })
+
+    it('exits non-zero when a lang file is malformed', () => {
+      const res = runCli(root => {
+        const dir = join(root, 'node_modules', 'adapt-authoring-foo', 'strings')
+        mkdirSync(dir, { recursive: true })
+        writeFileSync(join(dir, 'strings.json'), '{ not valid json')
+      })
+      assert.equal(res.status, 1)
     })
   })
 })

--- a/tests/lang-check.spec.js
+++ b/tests/lang-check.spec.js
@@ -4,21 +4,90 @@ import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import Langcheck from '../bin/lang-check.js'
+import { reconcileLangKeys } from '../lib/utils/reconcileLangKeys.js'
+
+async function withRoot (build, run) {
+  // interpolating root into a glob pattern would parse '[id]' as a char class
+  const root = join(tmpdir(), `lang-check-root[id]-${Date.now()}-${process.hrtime()[1]}`)
+  try {
+    build(root)
+    return await run(root)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+}
+
+function writeJson (dir, name, obj) {
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, name), JSON.stringify(obj))
+}
 
 describe('Langcheck', () => {
   describe('#getTranslatedStrings()', () => {
     it('should collect strings when the root contains glob-significant characters', async () => {
-      // interpolating root into the pattern would parse '[id]' as a char class (and '\' as an escape on Windows)
-      const root = join(tmpdir(), `lang-check-root[id]-${Date.now()}`)
-      const langDir = join(root, 'adapt-authoring-foo', 'lang', 'en')
-      try {
-        mkdirSync(langDir, { recursive: true })
-        writeFileSync(join(langDir, 'app.json'), JSON.stringify({ title: 'x' }))
-        const keyMap = await Langcheck.prototype.getTranslatedStrings(root)
-        assert.deepEqual(keyMap.en, { 'app.title': false })
-      } finally {
-        rmSync(root, { recursive: true, force: true })
-      }
+      await withRoot(
+        root => writeJson(join(root, 'adapt-authoring-foo', 'lang', 'en'), 'app.json', { title: 'x' }),
+        async root => {
+          const keyMap = await Langcheck.prototype.getTranslatedStrings(root)
+          assert.deepEqual(keyMap.en, { 'app.title': false })
+        }
+      )
+    })
+
+    it('should collect strings from scoped modules', async () => {
+      await withRoot(
+        root => writeJson(join(root, '@scope', 'adapt-authoring-bar', 'lang', 'en'), 'app.json', { save: 'Save' }),
+        async root => {
+          const keyMap = await Langcheck.prototype.getTranslatedStrings(root)
+          assert.deepEqual(keyMap.en, { 'app.save': false })
+        }
+      )
+    })
+  })
+
+  describe('#getDeclaredKeys()', () => {
+    it('should collect declared string keys across scoped and unscoped modules', async () => {
+      await withRoot(
+        root => {
+          writeJson(join(root, 'adapt-authoring-foo', 'strings'), 'strings.json', { 'app.a': { description: 'A' }, 'app.fam': { pattern: true } })
+          writeJson(join(root, '@scope', 'adapt-authoring-bar', 'strings'), 'strings.json', { 'app.b': {} })
+        },
+        async root => {
+          const declared = await Langcheck.prototype.getDeclaredKeys(root)
+          assert.deepEqual(Object.keys(declared).sort(), ['app.a', 'app.b', 'app.fam'])
+          assert.equal(declared['app.fam'].pattern, true)
+        }
+      )
+    })
+  })
+
+  describe('#isDeclared()', () => {
+    it('should match exact keys and pattern prefixes', () => {
+      const lc = Langcheck.prototype
+      const declared = { 'app.exact': {}, 'app.fam': { pattern: true } }
+      assert.equal(lc.isDeclared('app.exact', declared), true)
+      assert.equal(lc.isDeclared('app.famchild', declared), true)
+      assert.equal(lc.isDeclared('app.other', declared), false)
+    })
+  })
+
+  describe('reconciliation over a fixture install', () => {
+    it('reports missing/orphan for app.* and ignores error.* entirely', async () => {
+      await withRoot(
+        root => {
+          writeJson(join(root, 'adapt-authoring-foo', 'strings'), 'strings.json', { 'app.a': {}, 'app.fam': { pattern: true } })
+          writeJson(join(root, '@scope', 'adapt-authoring-bar', 'lang', 'en'), 'app.json', { a: 'A', extra: 'E' })
+          writeJson(join(root, '@scope', 'adapt-authoring-bar', 'lang', 'en'), 'error.json', { BOOM: 'boom' })
+        },
+        async root => {
+          const declared = await Langcheck.prototype.getDeclaredKeys(root)
+          const translatedStrings = await Langcheck.prototype.getTranslatedStrings(root)
+          const translated = Object.keys(translatedStrings.en).filter(k => !k.startsWith('error.'))
+          const { missing, orphan } = reconcileLangKeys({ declared, translated })
+          assert.deepEqual(missing.sort(), ['app.fam'])
+          assert.deepEqual(orphan.sort(), ['app.extra'])
+        }
+      )
     })
   })
 })

--- a/tests/utils-reconcileLangKeys.spec.js
+++ b/tests/utils-reconcileLangKeys.spec.js
@@ -1,0 +1,52 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { reconcileLangKeys } from '../lib/utils/reconcileLangKeys.js'
+
+describe('reconcileLangKeys()', () => {
+  const cases = [
+    {
+      name: 'flags declared keys with no translation as missing',
+      declared: { 'app.a': {}, 'app.b': {} },
+      translated: ['app.a'],
+      missing: ['app.b'],
+      orphan: []
+    },
+    {
+      name: 'flags translated keys nothing declares as orphan',
+      declared: { 'app.a': {} },
+      translated: ['app.a', 'app.b'],
+      missing: [],
+      orphan: ['app.b']
+    },
+    {
+      name: 'a pattern entry is satisfied by any prefix-matching translation',
+      declared: { 'app.layout': { pattern: true } },
+      translated: ['app.layoutfull', 'app.layouthalf'],
+      missing: [],
+      orphan: []
+    },
+    {
+      name: 'a pattern entry with no matching translation is missing',
+      declared: { 'app.preset_': { pattern: true } },
+      translated: ['app.other'],
+      missing: ['app.preset_'],
+      orphan: ['app.other']
+    },
+    {
+      name: 'treats error codes fed as declared like any other key',
+      declared: { 'error.DUPL': {}, 'error.GONE': {} },
+      translated: ['error.DUPL', 'error.ORPHAN'],
+      missing: ['error.GONE'],
+      orphan: ['error.ORPHAN']
+    }
+  ]
+
+  for (const c of cases) {
+    it(c.name, () => {
+      const { missing, orphan } = reconcileLangKeys({ declared: c.declared, translated: c.translated })
+      assert.deepEqual(missing.sort(), c.missing.sort())
+      assert.deepEqual(orphan.sort(), c.orphan.sort())
+    })
+  }
+})


### PR DESCRIPTION
### Fixes #118

### Update
- `lang-check` now reconciles the keys modules declare in `strings/*.json` against the keys the langpacks translate (`lang/**/*.json`), instead of regex-scanning source for used literals.
- Missing translations (a declared key with no translation) fail the check; orphaned translations (a translation nothing declares) and keys used-in-code-but-undeclared are reported as warnings.
- Fixed module discovery to also match scoped packages.
- Added a shared `reconcileLangKeys` utility, with tests.

### Testing
- `npm test`
